### PR TITLE
Fix: S3Properties를 테스트에서 불러오지 못 하는 문제 해결

### DIFF
--- a/src/main/java/soon/fridgely/global/config/S3Config.java
+++ b/src/main/java/soon/fridgely/global/config/S3Config.java
@@ -11,11 +11,16 @@ import soon.fridgely.global.infra.properties.S3Properties;
 import soon.fridgely.global.infra.provider.S3Provider;
 import soon.fridgely.global.infra.provider.StorageProvider;
 
-@Profile("live")
+/**
+ * S3 설정
+ * - S3Properties: 모든 프로파일에서 활성화 (프로퍼티 검증용)
+ * - S3 빈(S3Client, S3Presigner, StorageProvider): live 프로파일에서만 생성
+ */
 @Configuration
 @EnableConfigurationProperties(S3Properties.class)
 public class S3Config {
 
+    @Profile("live")
     @Bean(destroyMethod = "close")
     public S3Client s3Client(S3Properties s3Properties) {
         Region region = Region.of(s3Properties.region().staticRegion());
@@ -24,6 +29,7 @@ public class S3Config {
             .build();
     }
 
+    @Profile("live")
     @Bean(destroyMethod = "close")
     public S3Presigner s3Presigner(S3Properties s3Properties) {
         Region region = Region.of(s3Properties.region().staticRegion());
@@ -32,6 +38,7 @@ public class S3Config {
             .build();
     }
 
+    @Profile("live")
     @Bean
     public StorageProvider storageProvider(
         S3Client s3Client,


### PR DESCRIPTION
- Resolves : #111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 클라우드 스토리지 구성 요소의 프로필 제한 설정을 최적화했습니다. 이제 S3 관련 서비스가 프로덕션 환경에서만 활성화되도록 개선되어, 환경별 설정 관리가 더욱 명확하고 효율적으로 처리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->