### PR TITLE
Feat: Caffeine Cache 도입을 통해 API 응답 지연시간 단축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -69,6 +70,9 @@ dependencies {
 
     // monitoring
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // cache(caffeine)
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/soon/fridgely/domain/category/dto/command/CachedCategories.java
+++ b/src/main/java/soon/fridgely/domain/category/dto/command/CachedCategories.java
@@ -1,0 +1,21 @@
+package soon.fridgely.domain.category.dto.command;
+
+import soon.fridgely.domain.category.entity.Category;
+
+import java.util.List;
+
+public record CachedCategories(
+    long refrigeratorId,
+    List<CachedCategoryInfo> categories
+) {
+
+    public static CachedCategories from(long refrigeratorId, List<Category> categories) {
+        return new CachedCategories(
+            refrigeratorId,
+            categories.stream()
+                .map(CachedCategoryInfo::from)
+                .toList()
+        );
+    }
+
+}

--- a/src/main/java/soon/fridgely/domain/category/dto/command/CachedCategoryInfo.java
+++ b/src/main/java/soon/fridgely/domain/category/dto/command/CachedCategoryInfo.java
@@ -1,0 +1,19 @@
+package soon.fridgely.domain.category.dto.command;
+
+import soon.fridgely.domain.category.entity.Category;
+
+public record CachedCategoryInfo(
+    long id,
+    String name,
+    boolean isDefaultType
+) {
+
+    public static CachedCategoryInfo from(Category category) {
+        return new CachedCategoryInfo(
+            category.getId(),
+            category.getName(),
+            category.isDefaultType()
+        );
+    }
+
+}

--- a/src/main/java/soon/fridgely/domain/category/service/CategoryAppender.java
+++ b/src/main/java/soon/fridgely/domain/category/service/CategoryAppender.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.category.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,7 @@ public class CategoryAppender {
     private final RefrigeratorRepository refrigeratorRepository;
     private final MemberRepository memberRepository;
 
+    @CacheEvict(value = "categories", key = "#key.refrigeratorId()")
     public void appendDefaultCategories(MemberRefrigeratorKey key) {
         CategoryContext context = getContext(key);
         if (categoryRepository.existsByRefrigeratorAndStatus(context.refrigerator(), EntityStatus.ACTIVE)) {
@@ -45,6 +47,7 @@ public class CategoryAppender {
         categoryRepository.saveAll(categories);
     }
 
+    @CacheEvict(value = "categories", key = "#addCategory.refrigeratorId()")
     @Transactional
     public void appendCustomCategory(AddCategory addCategory) {
         CategoryContext context = getContext(addCategory.toKey());

--- a/src/main/java/soon/fridgely/domain/category/service/CategoryFinder.java
+++ b/src/main/java/soon/fridgely/domain/category/service/CategoryFinder.java
@@ -3,6 +3,7 @@ package soon.fridgely.domain.category.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.EntityStatus;
 import soon.fridgely.domain.category.dto.command.CachedCategories;
 import soon.fridgely.domain.category.entity.Category;
@@ -18,6 +19,7 @@ public class CategoryFinder {
 
     private final CategoryRepository categoryRepository;
 
+    @Transactional(readOnly = true)
     public Category findByRefrigerator(long categoryId, long refrigeratorId) {
         return categoryRepository.findByIdAndRefrigeratorIdAndStatus(
                 categoryId,
@@ -27,6 +29,7 @@ public class CategoryFinder {
             .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_DATA));
     }
 
+    @Transactional(readOnly = true)
     public Category findByName(String categoryName, long refrigeratorId) {
         return categoryRepository.findByNameAndRefrigeratorIdAndStatus(
                 categoryName,
@@ -37,6 +40,7 @@ public class CategoryFinder {
     }
 
     @Cacheable(value = "categories", key = "#refrigeratorId")
+    @Transactional(readOnly = true)
     public CachedCategories findAll(long refrigeratorId) {
         List<Category> categories = categoryRepository.findAllByRefrigeratorIdAndStatus(
             refrigeratorId,

--- a/src/main/java/soon/fridgely/domain/category/service/CategoryFinder.java
+++ b/src/main/java/soon/fridgely/domain/category/service/CategoryFinder.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import soon.fridgely.domain.EntityStatus;
+import soon.fridgely.domain.category.dto.command.CachedCategories;
 import soon.fridgely.domain.category.entity.Category;
 import soon.fridgely.domain.category.repository.CategoryRepository;
 import soon.fridgely.global.support.exception.CoreException;
@@ -36,11 +37,12 @@ public class CategoryFinder {
     }
 
     @Cacheable(value = "categories", key = "#refrigeratorId")
-    public List<Category> findAll(long refrigeratorId) {
-        return categoryRepository.findAllByRefrigeratorIdAndStatus(
+    public CachedCategories findAll(long refrigeratorId) {
+        List<Category> categories = categoryRepository.findAllByRefrigeratorIdAndStatus(
             refrigeratorId,
             EntityStatus.ACTIVE
         );
+        return CachedCategories.from(refrigeratorId, categories);
     }
 
 }

--- a/src/main/java/soon/fridgely/domain/category/service/CategoryFinder.java
+++ b/src/main/java/soon/fridgely/domain/category/service/CategoryFinder.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.category.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import soon.fridgely.domain.EntityStatus;
 import soon.fridgely.domain.category.entity.Category;
@@ -34,6 +35,7 @@ public class CategoryFinder {
             .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_DATA));
     }
 
+    @Cacheable(value = "categories", key = "#refrigeratorId")
     public List<Category> findAll(long refrigeratorId) {
         return categoryRepository.findAllByRefrigeratorIdAndStatus(
             refrigeratorId,

--- a/src/main/java/soon/fridgely/domain/category/service/CategoryModifier.java
+++ b/src/main/java/soon/fridgely/domain/category/service/CategoryModifier.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.category.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.category.dto.command.ModifyCategory;
@@ -14,6 +15,7 @@ public class CategoryModifier {
     private final CategoryFinder categoryFinder;
     private final CategoryValidator categoryValidator;
 
+    @CacheEvict(value = "categories", key = "#modifyCategory.refrigeratorId()")
     @Transactional
     public void modify(ModifyCategory modifyCategory) {
         Category category = categoryFinder.findByRefrigerator(modifyCategory.categoryId(), modifyCategory.refrigeratorId());

--- a/src/main/java/soon/fridgely/domain/category/service/CategoryRemover.java
+++ b/src/main/java/soon/fridgely/domain/category/service/CategoryRemover.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.category.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.category.dto.command.DeleteCategory;
@@ -19,6 +20,7 @@ public class CategoryRemover {
     private final FoodModifier foodModifier;
     private final CategoryRepository categoryRepository;
 
+    @CacheEvict(value = "categories", key = "#deleteCategory.refrigeratorId()")
     @Transactional
     public void remove(DeleteCategory deleteCategory) {
         Category category = categoryRepository.findByIdAndRefrigeratorId(deleteCategory.categoryId(), deleteCategory.refrigeratorId())

--- a/src/main/java/soon/fridgely/domain/category/service/CategoryService.java
+++ b/src/main/java/soon/fridgely/domain/category/service/CategoryService.java
@@ -33,7 +33,11 @@ public class CategoryService {
 
     @ValidateRefrigeratorAccess(key = "#key")
     public List<CategoryResponse> findAllCategory(MemberRefrigeratorKey key) {
-        return CategoryResponse.from(categoryFinder.findAll(key.refrigeratorId()));
+        return categoryFinder.findAll(key.refrigeratorId())
+            .categories()
+            .stream()
+            .map(info -> new CategoryResponse(info.id(), info.name(), info.isDefaultType()))
+            .toList();
     }
 
     @ValidateRefrigeratorAccess(key = "#modifyCategory.toKey()")

--- a/src/main/java/soon/fridgely/domain/refrigerator/dto/command/CachedMemberRefrigerators.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/dto/command/CachedMemberRefrigerators.java
@@ -1,0 +1,21 @@
+package soon.fridgely.domain.refrigerator.dto.command;
+
+import soon.fridgely.domain.refrigerator.entity.MemberRefrigerator;
+
+import java.util.List;
+
+public record CachedMemberRefrigerators(
+    long memberId,
+    List<CachedRefrigeratorInfo> refrigerators
+) {
+
+    public static CachedMemberRefrigerators from(long memberId, List<MemberRefrigerator> refrigerators) {
+        return new CachedMemberRefrigerators(
+            memberId,
+            refrigerators.stream()
+                .map(CachedRefrigeratorInfo::from)
+                .toList()
+        );
+    }
+
+}

--- a/src/main/java/soon/fridgely/domain/refrigerator/dto/command/CachedRefrigeratorInfo.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/dto/command/CachedRefrigeratorInfo.java
@@ -1,0 +1,22 @@
+package soon.fridgely.domain.refrigerator.dto.command;
+
+import soon.fridgely.domain.refrigerator.entity.MemberRefrigerator;
+import soon.fridgely.domain.refrigerator.entity.RefrigeratorRole;
+
+public record CachedRefrigeratorInfo(
+    long id,
+    String name,
+    RefrigeratorRole role,
+    boolean isOwner
+) {
+
+    public static CachedRefrigeratorInfo from(MemberRefrigerator memberRefrigerator) {
+        return new CachedRefrigeratorInfo(
+            memberRefrigerator.getRefrigerator().getId(),
+            memberRefrigerator.getRefrigerator().getName(),
+            memberRefrigerator.getRole(),
+            memberRefrigerator.isOwner()
+        );
+    }
+
+}

--- a/src/main/java/soon/fridgely/domain/refrigerator/dto/response/RefrigeratorResponse.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/dto/response/RefrigeratorResponse.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.refrigerator.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import soon.fridgely.domain.refrigerator.dto.command.CachedRefrigeratorInfo;
 import soon.fridgely.domain.refrigerator.entity.MemberRefrigerator;
 import soon.fridgely.domain.refrigerator.entity.Refrigerator;
 import soon.fridgely.domain.refrigerator.entity.RefrigeratorRole;
@@ -29,6 +30,15 @@ public record RefrigeratorResponse(
             refrigerator.getName(),
             memberRefrigerator.getRole(),
             memberRefrigerator.isOwner()
+        );
+    }
+
+    public static RefrigeratorResponse from(CachedRefrigeratorInfo info) {
+        return new RefrigeratorResponse(
+            info.id(),
+            info.name(),
+            info.role(),
+            info.isOwner()
         );
     }
 

--- a/src/main/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorFinder.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorFinder.java
@@ -5,6 +5,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.EntityStatus;
+import soon.fridgely.domain.refrigerator.dto.command.CachedMemberRefrigerators;
 import soon.fridgely.domain.refrigerator.entity.MemberRefrigerator;
 import soon.fridgely.domain.refrigerator.repository.MemberRefrigeratorRepository;
 import soon.fridgely.global.support.exception.CoreException;
@@ -20,8 +21,9 @@ public class MemberRefrigeratorFinder {
 
     @Cacheable(value = "myRefrigerators", key = "#memberId")
     @Transactional(readOnly = true)
-    public List<MemberRefrigerator> findAllByMemberId(long memberId) {
-        return memberRefrigeratorRepository.findAllMyRefrigerators(memberId, EntityStatus.ACTIVE);
+    public CachedMemberRefrigerators findAllByMemberId(long memberId) {
+        List<MemberRefrigerator> refrigerators = memberRefrigeratorRepository.findAllMyRefrigerators(memberId, EntityStatus.ACTIVE);
+        return CachedMemberRefrigerators.from(memberId, refrigerators);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorFinder.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorFinder.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.refrigerator.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.EntityStatus;
@@ -17,6 +18,7 @@ public class MemberRefrigeratorFinder {
 
     private final MemberRefrigeratorRepository memberRefrigeratorRepository;
 
+    @Cacheable(value = "myRefrigerators", key = "#memberId")
     @Transactional(readOnly = true)
     public List<MemberRefrigerator> findAllByMemberId(long memberId) {
         return memberRefrigeratorRepository.findAllMyRefrigerators(memberId, EntityStatus.ACTIVE);

--- a/src/main/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorLinker.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorLinker.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.refrigerator.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.EntityStatus;
@@ -23,11 +24,13 @@ public class MemberRefrigeratorLinker {
     private final RefrigeratorRepository refrigeratorRepository;
     private final MemberRepository memberRepository;
 
+    @CacheEvict(value = "myRefrigerators", key = "#member.id")
     public void linkToOwner(Member member, Refrigerator refrigerator) {
         MemberRefrigerator memberRefrigerator = MemberRefrigerator.link(member, refrigerator, RefrigeratorRole.OWNER);
         memberRefrigeratorRepository.save(memberRefrigerator);
     }
 
+    @CacheEvict(value = "myRefrigerators", key = "#key.memberId()")
     @Transactional
     public void linkMemberToRefrigerator(MemberRefrigeratorKey key, RefrigeratorRole role) {
         if (memberRefrigeratorRepository.existsByRefrigeratorIdAndMemberIdAndStatus(key.refrigeratorId(), key.memberId(), EntityStatus.ACTIVE)) {

--- a/src/main/java/soon/fridgely/domain/refrigerator/service/RefrigeratorManager.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/service/RefrigeratorManager.java
@@ -1,6 +1,7 @@
 package soon.fridgely.domain.refrigerator.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.EntityStatus;
@@ -24,6 +25,7 @@ public class RefrigeratorManager {
         return refrigeratorRepository.save(register);
     }
 
+    @CacheEvict(value = "myRefrigerators", allEntries = true)
     @Transactional
     public void update(long refrigeratorId, String newName) {
         Refrigerator refrigerator = refrigeratorRepository.findByIdAndStatus(refrigeratorId, EntityStatus.ACTIVE)

--- a/src/main/java/soon/fridgely/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/service/RefrigeratorService.java
@@ -61,7 +61,7 @@ public class RefrigeratorService {
         return memberRefrigeratorFinder.findAllByMemberId(memberId)
             .refrigerators()
             .stream()
-            .map(info -> new RefrigeratorResponse(info.id(), info.name(), info.role(), info.isOwner()))
+            .map(RefrigeratorResponse::from)
             .toList();
     }
 

--- a/src/main/java/soon/fridgely/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/soon/fridgely/domain/refrigerator/service/RefrigeratorService.java
@@ -59,8 +59,9 @@ public class RefrigeratorService {
     @Transactional(readOnly = true)
     public List<RefrigeratorResponse> findAllMyRefrigerators(Long memberId) {
         return memberRefrigeratorFinder.findAllByMemberId(memberId)
+            .refrigerators()
             .stream()
-            .map(RefrigeratorResponse::from)
+            .map(info -> new RefrigeratorResponse(info.id(), info.name(), info.role(), info.isOwner()))
             .toList();
     }
 

--- a/src/main/java/soon/fridgely/global/config/CacheConfig.java
+++ b/src/main/java/soon/fridgely/global/config/CacheConfig.java
@@ -1,0 +1,46 @@
+package soon.fridgely.global.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@EnableCaching
+@Configuration
+@ConditionalOnProperty(name = "spring.cache.type", havingValue = "caffeine")
+public class CacheConfig {
+
+    private static final int CATEGORIES_TTL_HOURS = 24;
+    private static final int CATEGORIES_MAX_SIZE = 100;
+
+    private static final int REFRIGERATORS_TTL_HOURS = 1;
+    private static final int REFRIGERATORS_MAX_SIZE = 1000;
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.registerCustomCache("categories", buildCache(CATEGORIES_TTL_HOURS, CATEGORIES_MAX_SIZE));
+        cacheManager.registerCustomCache("myRefrigerators", buildCache(REFRIGERATORS_TTL_HOURS, REFRIGERATORS_MAX_SIZE));
+
+        log.info("[CacheConfig] Caffeine 캐시 설정 완료 (categories: {}h, myRefrigerators: {}h)", CATEGORIES_TTL_HOURS, REFRIGERATORS_TTL_HOURS);
+
+        return cacheManager;
+    }
+
+    private Cache<Object, Object> buildCache(int ttlHours, int maxSize) {
+        return Caffeine.newBuilder()
+            .expireAfterWrite(ttlHours, TimeUnit.HOURS)
+            .maximumSize(maxSize)
+            .recordStats() // 캐시 통계 기록 활성화
+            .build();
+    }
+
+}

--- a/src/main/java/soon/fridgely/global/config/CacheConfig.java
+++ b/src/main/java/soon/fridgely/global/config/CacheConfig.java
@@ -2,6 +2,9 @@ package soon.fridgely.global.config;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.CacheManager;
@@ -13,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
+@RequiredArgsConstructor
 @EnableCaching
 @Configuration
 @ConditionalOnProperty(name = "spring.cache.type", havingValue = "caffeine")
@@ -24,11 +28,20 @@ public class CacheConfig {
     private static final int REFRIGERATORS_TTL_HOURS = 1;
     private static final int REFRIGERATORS_MAX_SIZE = 1000;
 
+    private final MeterRegistry meterRegistry;
+
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-        cacheManager.registerCustomCache("categories", buildCache(CATEGORIES_TTL_HOURS, CATEGORIES_MAX_SIZE));
-        cacheManager.registerCustomCache("myRefrigerators", buildCache(REFRIGERATORS_TTL_HOURS, REFRIGERATORS_MAX_SIZE));
+
+        Cache<Object, Object> categoriesCache = buildCache(CATEGORIES_TTL_HOURS, CATEGORIES_MAX_SIZE);
+        Cache<Object, Object> refrigeratorsCache = buildCache(REFRIGERATORS_TTL_HOURS, REFRIGERATORS_MAX_SIZE);
+
+        cacheManager.registerCustomCache("categories", categoriesCache);
+        cacheManager.registerCustomCache("myRefrigerators", refrigeratorsCache);
+
+        CaffeineCacheMetrics.monitor(meterRegistry, categoriesCache, "categories");
+        CaffeineCacheMetrics.monitor(meterRegistry, refrigeratorsCache, "myRefrigerators");
 
         log.info("[CacheConfig] Caffeine 캐시 설정 완료 (categories: {}h, myRefrigerators: {}h)", CATEGORIES_TTL_HOURS, REFRIGERATORS_TTL_HOURS);
 
@@ -39,7 +52,7 @@ public class CacheConfig {
         return Caffeine.newBuilder()
             .expireAfterWrite(ttlHours, TimeUnit.HOURS)
             .maximumSize(maxSize)
-            .recordStats() // 캐시 통계 기록 활성화
+            .recordStats()
             .build();
     }
 

--- a/src/test/java/soon/fridgely/domain/category/service/CategoryCacheIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/category/service/CategoryCacheIntegrationTest.java
@@ -1,0 +1,291 @@
+package soon.fridgely.domain.category.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.TestPropertySource;
+import soon.fridgely.domain.category.dto.command.AddCategory;
+import soon.fridgely.domain.category.dto.command.DeleteCategory;
+import soon.fridgely.domain.category.dto.command.ModifyCategory;
+import soon.fridgely.domain.category.entity.Category;
+import soon.fridgely.domain.category.repository.CategoryRepository;
+import soon.fridgely.domain.member.entity.Member;
+import soon.fridgely.domain.member.repository.MemberRepository;
+import soon.fridgely.domain.refrigerator.dto.command.MemberRefrigeratorKey;
+import soon.fridgely.domain.refrigerator.entity.Refrigerator;
+import soon.fridgely.domain.refrigerator.repository.RefrigeratorRepository;
+import soon.fridgely.global.support.IntegrationTestSupport;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static soon.fridgely.global.support.fixture.MemberFixture.member;
+import static soon.fridgely.global.support.fixture.RefrigeratorFixture.refrigerator;
+
+@TestPropertySource(properties = "spring.cache.type=caffeine")
+class CategoryCacheIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CategoryFinder categoryFinder;
+
+    @Autowired
+    private CategoryAppender categoryAppender;
+
+    @Autowired
+    private CategoryModifier categoryModifier;
+
+    @Autowired
+    private CategoryRemover categoryRemover;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RefrigeratorRepository refrigeratorRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    private Member member;
+    private Refrigerator refrigerator;
+
+    @BeforeEach
+    void setUp() {
+        this.member = memberRepository.save(
+            member(fixtureMonkey).sample()
+        );
+        this.refrigerator = refrigeratorRepository.save(
+            refrigerator(fixtureMonkey).sample()
+        );
+
+        Cache cache = cacheManager.getCache("categories");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @Test
+    void 카테고리_목록_조회_시_캐시가_적용된다() {
+        // given
+        MemberRefrigeratorKey key = new MemberRefrigeratorKey(member.getId(), refrigerator.getId());
+        categoryAppender.appendDefaultCategories(key);
+
+        // when
+        List<Category> firstResult = categoryFinder.findAll(refrigerator.getId());
+        assertThat(firstResult).hasSize(8);
+
+        Cache cache = cacheManager.getCache("categories");
+        assertThat(cache).isNotNull();
+        assertThat(cache.get(refrigerator.getId())).isNotNull();
+
+
+        List<Category> secondResult = categoryFinder.findAll(refrigerator.getId()); // 같은 인스턴스 반환
+        // then
+        assertThat(secondResult).hasSize(8);
+        assertThat(firstResult).isEqualTo(secondResult);
+    }
+
+    @Test
+    void 커스텀_카테고리_추가_시_캐시가_무효화된다() {
+        // given
+        MemberRefrigeratorKey key = new MemberRefrigeratorKey(member.getId(), refrigerator.getId());
+        categoryAppender.appendDefaultCategories(key);
+
+        List<Category> cachedResult = categoryFinder.findAll(refrigerator.getId());
+        assertThat(cachedResult).hasSize(8);
+
+        // when
+        AddCategory addCategory = new AddCategory("새 카테고리", refrigerator.getId(), member.getId());
+        categoryAppender.appendCustomCategory(addCategory);
+
+        // then
+        List<Category> updatedResult = categoryFinder.findAll(refrigerator.getId());
+        assertThat(updatedResult).hasSize(9)
+            .extracting(Category::getName)
+            .contains("새 카테고리");
+    }
+
+    @Test
+    void 기본_카테고리_생성_시_캐시가_무효화된다() {
+        // given
+        MemberRefrigeratorKey key = new MemberRefrigeratorKey(member.getId(), refrigerator.getId());
+
+        // when
+        categoryAppender.appendDefaultCategories(key);
+
+        Cache cache = cacheManager.getCache("categories");
+        assertThat(cache.get(refrigerator.getId())).isNull();
+
+        List<Category> categories = categoryFinder.findAll(refrigerator.getId());
+
+        // then
+        assertThat(categories).hasSize(8)
+            .extracting(Category::getName)
+            .containsExactlyInAnyOrder("야채", "과일", "육류", "해산물", "유제품", "음료", "간식", "기타");
+    }
+
+    @Test
+    void 카테고리_수정_시_캐시가_무효화된다() {
+        // given
+        MemberRefrigeratorKey key = new MemberRefrigeratorKey(member.getId(), refrigerator.getId());
+        categoryAppender.appendDefaultCategories(key);
+
+        AddCategory addCategory = new AddCategory("수정될 카테고리", refrigerator.getId(), member.getId());
+        categoryAppender.appendCustomCategory(addCategory);
+
+        List<Category> cachedCategories = categoryFinder.findAll(refrigerator.getId());
+        Category targetCategory = cachedCategories.stream()
+            .filter(c -> c.getName().equals("수정될 카테고리"))
+            .findFirst()
+            .orElseThrow();
+
+        // when
+        ModifyCategory modifyCategory = new ModifyCategory(
+            "수정된 카테고리",
+            member.getId(),
+            refrigerator.getId(),
+            targetCategory.getId()
+        );
+        categoryModifier.modify(modifyCategory);
+
+        // then
+        List<Category> updatedCategories = categoryFinder.findAll(refrigerator.getId());
+        assertThat(updatedCategories)
+            .extracting(Category::getName)
+            .contains("수정된 카테고리")
+            .doesNotContain("수정될 카테고리");
+    }
+
+    @Test
+    void 카테고리_삭제_시_캐시가_무효화된다() {
+        // given
+        MemberRefrigeratorKey key = new MemberRefrigeratorKey(member.getId(), refrigerator.getId());
+        categoryAppender.appendDefaultCategories(key);
+        AddCategory addCategory = new AddCategory("삭제될 카테고리", refrigerator.getId(), member.getId());
+        categoryAppender.appendCustomCategory(addCategory);
+
+        List<Category> cachedCategories = categoryFinder.findAll(refrigerator.getId());
+        Category targetCategory = cachedCategories.stream()
+            .filter(c -> c.getName().equals("삭제될 카테고리"))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(cachedCategories).hasSize(9);
+
+        // when - 카테고리 삭제
+        DeleteCategory deleteCategory = new DeleteCategory(
+            member.getId(),
+            refrigerator.getId(),
+            targetCategory.getId()
+        );
+        categoryRemover.remove(deleteCategory);
+
+        // then - 캐시가 무효화되어 DB에서 최신 데이터 조회
+        List<Category> updatedCategories = categoryFinder.findAll(refrigerator.getId());
+        assertThat(updatedCategories)
+            .extracting(Category::getName)
+            .doesNotContain("삭제될 카테고리");
+    }
+
+    @Test
+    void 서로_다른_냉장고의_카테고리_캐시는_독립적으로_동작한다() {
+        // given
+        Member member2 = memberRepository.save(member(fixtureMonkey).sample());
+        Refrigerator refrigerator2 = refrigeratorRepository.save(refrigerator(fixtureMonkey).sample());
+
+        MemberRefrigeratorKey key1 = new MemberRefrigeratorKey(member.getId(), refrigerator.getId());
+        MemberRefrigeratorKey key2 = new MemberRefrigeratorKey(member2.getId(), refrigerator2.getId());
+
+        categoryAppender.appendDefaultCategories(key1);
+        categoryAppender.appendDefaultCategories(key2);
+
+        categoryFinder.findAll(refrigerator.getId());
+        categoryFinder.findAll(refrigerator2.getId());
+
+        Cache cache = cacheManager.getCache("categories");
+        assertThat(cache.get(refrigerator.getId())).isNotNull();
+        assertThat(cache.get(refrigerator2.getId())).isNotNull();
+
+        // when
+        AddCategory addCategory = new AddCategory("새 카테고리", refrigerator.getId(), member.getId());
+        categoryAppender.appendCustomCategory(addCategory);
+
+        // then
+        assertThat(cache.get(refrigerator.getId())).isNull();
+        assertThat(cache.get(refrigerator2.getId())).isNotNull();
+
+        List<Category> refrigerator1Categories = categoryFinder.findAll(refrigerator.getId());
+        List<Category> refrigerator2Categories = categoryFinder.findAll(refrigerator2.getId());
+
+        assertThat(refrigerator1Categories).hasSize(9);
+        assertThat(refrigerator2Categories).hasSize(8);
+    }
+
+    @Test
+    void 캐시_키가_refrigeratorId로_정확하게_생성된다() {
+        // given
+        categoryAppender.appendDefaultCategories(
+            new MemberRefrigeratorKey(member.getId(), refrigerator.getId())
+        );
+
+        // when
+        categoryFinder.findAll(refrigerator.getId());
+
+        // then
+        Cache cache = cacheManager.getCache("categories");
+        assertThat(cache).isNotNull();
+        assertThat(cache.get(refrigerator.getId())).isNotNull();
+        assertThat(cache.get(refrigerator.getId()).get()).isInstanceOf(List.class);
+    }
+
+    @Test
+    void 캐시된_데이터와_DB_데이터가_일치한다() {
+        // given
+        categoryAppender.appendDefaultCategories(
+            new MemberRefrigeratorKey(member.getId(), refrigerator.getId())
+        );
+
+        // when
+        List<Category> cachedResult = categoryFinder.findAll(refrigerator.getId());
+
+        // then
+        List<Category> dbResult = categoryRepository.findAllByRefrigeratorIdAndStatus(
+            refrigerator.getId(),
+            soon.fridgely.domain.EntityStatus.ACTIVE
+        );
+        assertThat(cachedResult).hasSize(dbResult.size());
+        assertThat(cachedResult)
+            .extracting(Category::getName)
+            .containsExactlyInAnyOrderElementsOf(
+                dbResult.stream().map(Category::getName).toList()
+            );
+    }
+
+    @Test
+    void 캐시_무효화_후_재조회_시_최신_데이터를_가져온다() {
+        // given
+        categoryAppender.appendDefaultCategories(
+            new MemberRefrigeratorKey(member.getId(), refrigerator.getId())
+        );
+        categoryFinder.findAll(refrigerator.getId());
+
+        // when
+        categoryAppender.appendCustomCategory(
+            new AddCategory("테스트 카테고리", refrigerator.getId(), member.getId())
+        );
+
+        // then
+        List<Category> firstResult = categoryFinder.findAll(refrigerator.getId());
+        List<Category> secondResult = categoryFinder.findAll(refrigerator.getId());
+
+        assertThat(firstResult).hasSize(9);
+        assertThat(secondResult).hasSize(9);
+        assertThat(firstResult).isEqualTo(secondResult);
+    }
+
+}

--- a/src/test/java/soon/fridgely/domain/category/service/CategoryCacheIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/category/service/CategoryCacheIntegrationTest.java
@@ -6,9 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.TestPropertySource;
-import soon.fridgely.domain.category.dto.command.AddCategory;
-import soon.fridgely.domain.category.dto.command.DeleteCategory;
-import soon.fridgely.domain.category.dto.command.ModifyCategory;
+import soon.fridgely.domain.category.dto.command.*;
 import soon.fridgely.domain.category.entity.Category;
 import soon.fridgely.domain.category.repository.CategoryRepository;
 import soon.fridgely.domain.member.entity.Member;
@@ -76,17 +74,16 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         categoryAppender.appendDefaultCategories(key);
 
         // when
-        List<Category> firstResult = categoryFinder.findAll(refrigerator.getId());
-        assertThat(firstResult).hasSize(8);
+        CachedCategories firstResult = categoryFinder.findAll(refrigerator.getId());
 
+        // then
+        assertThat(firstResult.categories()).hasSize(8);
         Cache cache = cacheManager.getCache("categories");
         assertThat(cache).isNotNull();
         assertThat(cache.get(refrigerator.getId())).isNotNull();
 
-
-        List<Category> secondResult = categoryFinder.findAll(refrigerator.getId()); // 같은 인스턴스 반환
-        // then
-        assertThat(secondResult).hasSize(8);
+        CachedCategories secondResult = categoryFinder.findAll(refrigerator.getId());
+        assertThat(secondResult.categories()).hasSize(8);
         assertThat(firstResult).isEqualTo(secondResult);
     }
 
@@ -96,17 +93,17 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         MemberRefrigeratorKey key = new MemberRefrigeratorKey(member.getId(), refrigerator.getId());
         categoryAppender.appendDefaultCategories(key);
 
-        List<Category> cachedResult = categoryFinder.findAll(refrigerator.getId());
-        assertThat(cachedResult).hasSize(8);
+        CachedCategories cachedResult = categoryFinder.findAll(refrigerator.getId());
+        assertThat(cachedResult.categories()).hasSize(8);
 
         // when
         AddCategory addCategory = new AddCategory("새 카테고리", refrigerator.getId(), member.getId());
         categoryAppender.appendCustomCategory(addCategory);
 
         // then
-        List<Category> updatedResult = categoryFinder.findAll(refrigerator.getId());
-        assertThat(updatedResult).hasSize(9)
-            .extracting(Category::getName)
+        CachedCategories updatedResult = categoryFinder.findAll(refrigerator.getId());
+        assertThat(updatedResult.categories()).hasSize(9)
+            .extracting(CachedCategoryInfo::name)
             .contains("새 카테고리");
     }
 
@@ -118,14 +115,13 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         // when
         categoryAppender.appendDefaultCategories(key);
 
+        // then
         Cache cache = cacheManager.getCache("categories");
         assertThat(cache.get(refrigerator.getId())).isNull();
 
-        List<Category> categories = categoryFinder.findAll(refrigerator.getId());
-
-        // then
-        assertThat(categories).hasSize(8)
-            .extracting(Category::getName)
+        CachedCategories categories = categoryFinder.findAll(refrigerator.getId());
+        assertThat(categories.categories()).hasSize(8)
+            .extracting(CachedCategoryInfo::name)
             .containsExactlyInAnyOrder("야채", "과일", "육류", "해산물", "유제품", "음료", "간식", "기타");
     }
 
@@ -138,9 +134,9 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         AddCategory addCategory = new AddCategory("수정될 카테고리", refrigerator.getId(), member.getId());
         categoryAppender.appendCustomCategory(addCategory);
 
-        List<Category> cachedCategories = categoryFinder.findAll(refrigerator.getId());
-        Category targetCategory = cachedCategories.stream()
-            .filter(c -> c.getName().equals("수정될 카테고리"))
+        CachedCategories cachedCategories = categoryFinder.findAll(refrigerator.getId());
+        CachedCategoryInfo targetCategory = cachedCategories.categories().stream()
+            .filter(c -> c.name().equals("수정될 카테고리"))
             .findFirst()
             .orElseThrow();
 
@@ -149,14 +145,14 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
             "수정된 카테고리",
             member.getId(),
             refrigerator.getId(),
-            targetCategory.getId()
+            targetCategory.id()
         );
         categoryModifier.modify(modifyCategory);
 
         // then
-        List<Category> updatedCategories = categoryFinder.findAll(refrigerator.getId());
-        assertThat(updatedCategories)
-            .extracting(Category::getName)
+        CachedCategories updatedCategories = categoryFinder.findAll(refrigerator.getId());
+        assertThat(updatedCategories.categories())
+            .extracting(CachedCategoryInfo::name)
             .contains("수정된 카테고리")
             .doesNotContain("수정될 카테고리");
     }
@@ -169,26 +165,26 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         AddCategory addCategory = new AddCategory("삭제될 카테고리", refrigerator.getId(), member.getId());
         categoryAppender.appendCustomCategory(addCategory);
 
-        List<Category> cachedCategories = categoryFinder.findAll(refrigerator.getId());
-        Category targetCategory = cachedCategories.stream()
-            .filter(c -> c.getName().equals("삭제될 카테고리"))
+        CachedCategories cachedCategories = categoryFinder.findAll(refrigerator.getId());
+        CachedCategoryInfo targetCategory = cachedCategories.categories().stream()
+            .filter(c -> c.name().equals("삭제될 카테고리"))
             .findFirst()
             .orElseThrow();
 
-        assertThat(cachedCategories).hasSize(9);
+        assertThat(cachedCategories.categories()).hasSize(9);
 
-        // when - 카테고리 삭제
+        // when
         DeleteCategory deleteCategory = new DeleteCategory(
             member.getId(),
             refrigerator.getId(),
-            targetCategory.getId()
+            targetCategory.id()
         );
         categoryRemover.remove(deleteCategory);
 
-        // then - 캐시가 무효화되어 DB에서 최신 데이터 조회
-        List<Category> updatedCategories = categoryFinder.findAll(refrigerator.getId());
-        assertThat(updatedCategories)
-            .extracting(Category::getName)
+        // then
+        CachedCategories updatedCategories = categoryFinder.findAll(refrigerator.getId());
+        assertThat(updatedCategories.categories())
+            .extracting(CachedCategoryInfo::name)
             .doesNotContain("삭제될 카테고리");
     }
 
@@ -219,11 +215,11 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         assertThat(cache.get(refrigerator.getId())).isNull();
         assertThat(cache.get(refrigerator2.getId())).isNotNull();
 
-        List<Category> refrigerator1Categories = categoryFinder.findAll(refrigerator.getId());
-        List<Category> refrigerator2Categories = categoryFinder.findAll(refrigerator2.getId());
+        CachedCategories refrigerator1Categories = categoryFinder.findAll(refrigerator.getId());
+        CachedCategories refrigerator2Categories = categoryFinder.findAll(refrigerator2.getId());
 
-        assertThat(refrigerator1Categories).hasSize(9);
-        assertThat(refrigerator2Categories).hasSize(8);
+        assertThat(refrigerator1Categories.categories()).hasSize(9);
+        assertThat(refrigerator2Categories.categories()).hasSize(8);
     }
 
     @Test
@@ -240,7 +236,7 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         Cache cache = cacheManager.getCache("categories");
         assertThat(cache).isNotNull();
         assertThat(cache.get(refrigerator.getId())).isNotNull();
-        assertThat(cache.get(refrigerator.getId()).get()).isInstanceOf(List.class);
+        assertThat(cache.get(refrigerator.getId()).get()).isInstanceOf(CachedCategories.class);
     }
 
     @Test
@@ -251,16 +247,16 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
         );
 
         // when
-        List<Category> cachedResult = categoryFinder.findAll(refrigerator.getId());
+        CachedCategories cachedResult = categoryFinder.findAll(refrigerator.getId());
 
         // then
         List<Category> dbResult = categoryRepository.findAllByRefrigeratorIdAndStatus(
             refrigerator.getId(),
             soon.fridgely.domain.EntityStatus.ACTIVE
         );
-        assertThat(cachedResult).hasSize(dbResult.size());
-        assertThat(cachedResult)
-            .extracting(Category::getName)
+        assertThat(cachedResult.categories()).hasSize(dbResult.size());
+        assertThat(cachedResult.categories())
+            .extracting(CachedCategoryInfo::name)
             .containsExactlyInAnyOrderElementsOf(
                 dbResult.stream().map(Category::getName).toList()
             );
@@ -269,22 +265,17 @@ class CategoryCacheIntegrationTest extends IntegrationTestSupport {
     @Test
     void 캐시_무효화_후_재조회_시_최신_데이터를_가져온다() {
         // given
-        categoryAppender.appendDefaultCategories(
-            new MemberRefrigeratorKey(member.getId(), refrigerator.getId())
-        );
+        categoryAppender.appendDefaultCategories(new MemberRefrigeratorKey(member.getId(), refrigerator.getId()));
         categoryFinder.findAll(refrigerator.getId());
 
         // when
-        categoryAppender.appendCustomCategory(
-            new AddCategory("테스트 카테고리", refrigerator.getId(), member.getId())
-        );
+        categoryAppender.appendCustomCategory(new AddCategory("테스트 카테고리", refrigerator.getId(), member.getId()));
 
         // then
-        List<Category> firstResult = categoryFinder.findAll(refrigerator.getId());
-        List<Category> secondResult = categoryFinder.findAll(refrigerator.getId());
-
-        assertThat(firstResult).hasSize(9);
-        assertThat(secondResult).hasSize(9);
+        CachedCategories firstResult = categoryFinder.findAll(refrigerator.getId());
+        CachedCategories secondResult = categoryFinder.findAll(refrigerator.getId());
+        assertThat(firstResult.categories()).hasSize(9);
+        assertThat(secondResult.categories()).hasSize(9);
         assertThat(firstResult).isEqualTo(secondResult);
     }
 

--- a/src/test/java/soon/fridgely/domain/category/service/CategoryFinderIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/category/service/CategoryFinderIntegrationTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import soon.fridgely.domain.EntityStatus;
+import soon.fridgely.domain.category.dto.command.CachedCategories;
+import soon.fridgely.domain.category.dto.command.CachedCategoryInfo;
 import soon.fridgely.domain.category.entity.Category;
 import soon.fridgely.domain.category.entity.CategoryType;
 import soon.fridgely.domain.category.repository.CategoryRepository;
@@ -148,11 +150,11 @@ class CategoryFinderIntegrationTest extends IntegrationTestSupport {
         ));
 
         // when
-        List<Category> categories = categoryFinder.findAll(refrigerator.getId());
+        CachedCategories result = categoryFinder.findAll(refrigerator.getId());
 
         // then
-        assertThat(categories).hasSize(3)
-            .extracting("name")
+        assertThat(result.categories()).hasSize(3)
+            .extracting(CachedCategoryInfo::name)
             .containsExactlyInAnyOrder("카테고리1", "카테고리2", "카테고리3");
     }
 

--- a/src/test/java/soon/fridgely/domain/category/service/CategoryServiceUnitTest.java
+++ b/src/test/java/soon/fridgely/domain/category/service/CategoryServiceUnitTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import soon.fridgely.domain.category.dto.command.AddCategory;
+import soon.fridgely.domain.category.dto.command.CachedCategories;
 import soon.fridgely.domain.category.dto.command.DeleteCategory;
 import soon.fridgely.domain.category.dto.command.ModifyCategory;
 import soon.fridgely.domain.category.entity.Category;
@@ -83,6 +84,10 @@ class CategoryServiceUnitTest {
         var key = fixtureMonkey.giveMeBuilder(MemberRefrigeratorKey.class)
             .set("refrigeratorId", refrigeratorId)
             .sample();
+
+        var mockCachedCategories = fixtureMonkey.giveMeOne(CachedCategories.class);
+        given(categoryFinder.findAll(refrigeratorId))
+            .willReturn(mockCachedCategories);
 
         // when
         categoryService.findAllCategory(key);

--- a/src/test/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorFinderIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/refrigerator/service/MemberRefrigeratorFinderIntegrationTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import soon.fridgely.domain.member.entity.Member;
 import soon.fridgely.domain.member.repository.MemberRepository;
+import soon.fridgely.domain.refrigerator.dto.command.CachedMemberRefrigerators;
+import soon.fridgely.domain.refrigerator.dto.command.CachedRefrigeratorInfo;
 import soon.fridgely.domain.refrigerator.entity.MemberRefrigerator;
 import soon.fridgely.domain.refrigerator.entity.Refrigerator;
 import soon.fridgely.domain.refrigerator.entity.RefrigeratorRole;
@@ -74,11 +76,11 @@ class MemberRefrigeratorFinderIntegrationTest extends IntegrationTestSupport {
         ));
 
         // when
-        List<MemberRefrigerator> result = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        CachedMemberRefrigerators result = memberRefrigeratorFinder.findAllByMemberId(member.getId());
 
         // then
-        assertThat(result).hasSize(2)
-            .extracting("refrigerator.id", "role")
+        assertThat(result.refrigerators()).hasSize(2)
+            .extracting(CachedRefrigeratorInfo::id, CachedRefrigeratorInfo::role)
             .containsExactlyInAnyOrder(
                 tuple(refrigerator.getId(), RefrigeratorRole.OWNER),
                 tuple(myRefrigerator2.getId(), RefrigeratorRole.MEMBER)

--- a/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorCacheIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorCacheIntegrationTest.java
@@ -1,0 +1,252 @@
+package soon.fridgely.domain.refrigerator.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.TestPropertySource;
+import soon.fridgely.domain.member.entity.Member;
+import soon.fridgely.domain.member.repository.MemberRepository;
+import soon.fridgely.domain.refrigerator.dto.command.MemberRefrigeratorKey;
+import soon.fridgely.domain.refrigerator.entity.MemberRefrigerator;
+import soon.fridgely.domain.refrigerator.entity.Refrigerator;
+import soon.fridgely.domain.refrigerator.entity.RefrigeratorRole;
+import soon.fridgely.domain.refrigerator.repository.MemberRefrigeratorRepository;
+import soon.fridgely.domain.refrigerator.repository.RefrigeratorRepository;
+import soon.fridgely.global.support.IntegrationTestSupport;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static soon.fridgely.global.support.fixture.MemberFixture.member;
+import static soon.fridgely.global.support.fixture.RefrigeratorFixture.refrigerator;
+
+@TestPropertySource(properties = "spring.cache.type=caffeine")
+class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberRefrigeratorFinder memberRefrigeratorFinder;
+
+    @Autowired
+    private MemberRefrigeratorLinker memberRefrigeratorLinker;
+
+    @Autowired
+    private RefrigeratorManager refrigeratorManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RefrigeratorRepository refrigeratorRepository;
+
+    @Autowired
+    private MemberRefrigeratorRepository memberRefrigeratorRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    private Member member;
+    private Refrigerator refrigerator;
+
+    @BeforeEach
+    void setUp() {
+        this.member = memberRepository.save(member(fixtureMonkey).sample());
+        this.refrigerator = refrigeratorRepository.save(refrigerator(fixtureMonkey).sample());
+
+        Cache cache = cacheManager.getCache("myRefrigerators");
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    @Test
+    void 냉장고_목록_조회_시_캐시가_적용된다() {
+        // given
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+
+        // when
+        List<MemberRefrigerator> firstResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+
+        // then
+        assertThat(firstResult).hasSize(1);
+        Cache cache = cacheManager.getCache("myRefrigerators");
+        assertThat(cache).isNotNull();
+        assertThat(cache.get(member.getId())).isNotNull();
+
+        List<MemberRefrigerator> secondResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(secondResult).hasSize(1);
+        assertThat(firstResult).isEqualTo(secondResult);
+    }
+
+    @Test
+    void 냉장고_생성시_캐시가_무효화된다() {
+        // given
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+        List<MemberRefrigerator> cachedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(cachedResult).hasSize(1);
+
+        // when
+        Refrigerator refrigerator2 = refrigeratorRepository.save(refrigerator(fixtureMonkey).sample());
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator2);
+
+        // then
+        List<MemberRefrigerator> updatedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(updatedResult).hasSize(2)
+            .extracting(mr -> mr.getRefrigerator().getId())
+            .containsExactlyInAnyOrder(refrigerator.getId(), refrigerator2.getId());
+    }
+
+    @Test
+    void 초대_코드로_냉장고_참여시_해당_멤버의_캐시만_무효화된다() {
+        // given
+        Member member2 = memberRepository.save(member(fixtureMonkey).sample());
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+
+        memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+
+        Cache cache = cacheManager.getCache("myRefrigerators");
+        assertThat(cache.get(member.getId())).isNotNull();
+        assertThat(cache.get(member2.getId())).isNotNull();
+
+        // when
+        MemberRefrigeratorKey key = new MemberRefrigeratorKey(member2.getId(), refrigerator.getId());
+        memberRefrigeratorLinker.linkMemberToRefrigerator(key, RefrigeratorRole.MEMBER);
+
+        // then
+        assertThat(cache.get(member.getId())).isNotNull();
+        assertThat(cache.get(member2.getId())).isNull();
+
+        List<MemberRefrigerator> member2Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+        assertThat(member2Refrigerators).hasSize(1)
+            .extracting(mr -> mr.getRefrigerator().getId())
+            .containsExactly(refrigerator.getId());
+    }
+
+    @Test
+    void 냉장고_이름_수정시_모든_멤버의_캐시가_무효화된다() {
+        // given
+        Member member2 = memberRepository.save(member(fixtureMonkey).sample());
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+        MemberRefrigeratorKey key = new MemberRefrigeratorKey(member2.getId(), refrigerator.getId());
+        memberRefrigeratorLinker.linkMemberToRefrigerator(key, RefrigeratorRole.MEMBER);
+
+        memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+
+        Cache cache = cacheManager.getCache("myRefrigerators");
+        assertThat(cache.get(member.getId())).isNotNull();
+        assertThat(cache.get(member2.getId())).isNotNull();
+
+        // when
+        String newName = "새로운 냉장고 이름";
+        refrigeratorManager.update(refrigerator.getId(), newName);
+
+        // then
+        assertThat(cache.get(member.getId())).isNull();
+        assertThat(cache.get(member2.getId())).isNull();
+
+        List<MemberRefrigerator> member1Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        List<MemberRefrigerator> member2Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+
+        assertThat(member1Refrigerators.get(0).getRefrigerator().getName()).isEqualTo(newName);
+        assertThat(member2Refrigerators.get(0).getRefrigerator().getName()).isEqualTo(newName);
+    }
+
+    @Test
+    void 서로_다른_멤버의_냉장고_목록_캐시는_독립적으로_동작한다() {
+        // given
+        Member member2 = memberRepository.save(member(fixtureMonkey).sample());
+        Refrigerator refrigerator2 = refrigeratorRepository.save(refrigerator(fixtureMonkey).sample());
+
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+        memberRefrigeratorLinker.linkToOwner(member2, refrigerator2);
+
+        memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+
+        Cache cache = cacheManager.getCache("myRefrigerators");
+        assertThat(cache.get(member.getId())).isNotNull();
+        assertThat(cache.get(member2.getId())).isNotNull();
+
+        // when
+        Refrigerator refrigerator3 = refrigeratorRepository.save(refrigerator(fixtureMonkey).sample());
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator3);
+
+        // then
+        assertThat(cache.get(member.getId())).isNull();
+        assertThat(cache.get(member2.getId())).isNotNull();
+
+        List<MemberRefrigerator> memberRefrigerators = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(memberRefrigerators).hasSize(2)
+            .extracting(mr -> mr.getRefrigerator().getId())
+            .containsExactlyInAnyOrder(refrigerator.getId(), refrigerator3.getId());
+    }
+
+    @Test
+    void 캐시_키가_memberId로_정확하게_생성된다() {
+        // given
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+
+        // when
+        memberRefrigeratorFinder.findAllByMemberId(member.getId());
+
+        // then
+        Cache cache = cacheManager.getCache("myRefrigerators");
+        assertThat(cache).isNotNull();
+        assertThat(cache.get(member.getId())).isNotNull();
+        assertThat(cache.get(member.getId()).get()).isInstanceOf(List.class);
+    }
+
+    @Test
+    void allEntries_true로_전체_캐시가_무효화된다() {
+        // given
+        Member member2 = memberRepository.save(member(fixtureMonkey).sample());
+        Member member3 = memberRepository.save(member(fixtureMonkey).sample());
+        Refrigerator refrigerator2 = refrigeratorRepository.save(refrigerator(fixtureMonkey).sample());
+
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+        memberRefrigeratorLinker.linkToOwner(member2, refrigerator2);
+        memberRefrigeratorLinker.linkToOwner(member3, refrigerator2);
+
+        memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+        memberRefrigeratorFinder.findAllByMemberId(member3.getId());
+
+        Cache cache = cacheManager.getCache("myRefrigerators");
+        assertThat(cache.get(member.getId())).isNotNull();
+        assertThat(cache.get(member2.getId())).isNotNull();
+        assertThat(cache.get(member3.getId())).isNotNull();
+
+        // when
+        refrigeratorManager.update(refrigerator2.getId(), "업데이트된 냉장고");
+
+        // then
+        assertThat(cache.get(member.getId())).isNull();
+        assertThat(cache.get(member2.getId())).isNull();
+        assertThat(cache.get(member3.getId())).isNull();
+    }
+
+    @Test
+    void 캐시된_데이터와_DB_데이터가_일치한다() {
+        // given
+        memberRefrigeratorLinker.linkToOwner(member, refrigerator);
+
+        // when
+        List<MemberRefrigerator> cachedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        List<MemberRefrigerator> dbResult = memberRefrigeratorRepository.findAllMyRefrigerators(
+            member.getId(),
+            soon.fridgely.domain.EntityStatus.ACTIVE
+        );
+
+        // then
+        assertThat(cachedResult).hasSize(dbResult.size());
+        assertThat(cachedResult)
+            .extracting(mr -> mr.getRefrigerator().getId())
+            .containsExactlyInAnyOrderElementsOf(
+                dbResult.stream().map(mr -> mr.getRefrigerator().getId()).toList()
+            );
+    }
+
+}

--- a/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorCacheIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorCacheIntegrationTest.java
@@ -152,8 +152,12 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
         CachedMemberRefrigerators member1Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member.getId());
         CachedMemberRefrigerators member2Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member2.getId());
 
-        assertThat(member1Refrigerators.refrigerators().get(0).name()).isEqualTo(newName);
-        assertThat(member2Refrigerators.refrigerators().get(0).name()).isEqualTo(newName);
+        assertThat(member1Refrigerators.refrigerators())
+            .extracting(CachedRefrigeratorInfo::name)
+            .containsExactly(newName);
+        assertThat(member2Refrigerators.refrigerators())
+            .extracting(CachedRefrigeratorInfo::name)
+            .containsExactly(newName);
     }
 
     @Test

--- a/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorCacheIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorCacheIntegrationTest.java
@@ -8,6 +8,8 @@ import org.springframework.cache.CacheManager;
 import org.springframework.test.context.TestPropertySource;
 import soon.fridgely.domain.member.entity.Member;
 import soon.fridgely.domain.member.repository.MemberRepository;
+import soon.fridgely.domain.refrigerator.dto.command.CachedMemberRefrigerators;
+import soon.fridgely.domain.refrigerator.dto.command.CachedRefrigeratorInfo;
 import soon.fridgely.domain.refrigerator.dto.command.MemberRefrigeratorKey;
 import soon.fridgely.domain.refrigerator.entity.MemberRefrigerator;
 import soon.fridgely.domain.refrigerator.entity.Refrigerator;
@@ -66,16 +68,16 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
         memberRefrigeratorLinker.linkToOwner(member, refrigerator);
 
         // when
-        List<MemberRefrigerator> firstResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        CachedMemberRefrigerators firstResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
 
         // then
-        assertThat(firstResult).hasSize(1);
+        assertThat(firstResult.refrigerators()).hasSize(1);
         Cache cache = cacheManager.getCache("myRefrigerators");
         assertThat(cache).isNotNull();
         assertThat(cache.get(member.getId())).isNotNull();
 
-        List<MemberRefrigerator> secondResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
-        assertThat(secondResult).hasSize(1);
+        CachedMemberRefrigerators secondResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(secondResult.refrigerators()).hasSize(1);
         assertThat(firstResult).isEqualTo(secondResult);
     }
 
@@ -83,17 +85,17 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
     void 냉장고_생성시_캐시가_무효화된다() {
         // given
         memberRefrigeratorLinker.linkToOwner(member, refrigerator);
-        List<MemberRefrigerator> cachedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
-        assertThat(cachedResult).hasSize(1);
+        CachedMemberRefrigerators cachedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(cachedResult.refrigerators()).hasSize(1);
 
         // when
         Refrigerator refrigerator2 = refrigeratorRepository.save(refrigerator(fixtureMonkey).sample());
         memberRefrigeratorLinker.linkToOwner(member, refrigerator2);
 
         // then
-        List<MemberRefrigerator> updatedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
-        assertThat(updatedResult).hasSize(2)
-            .extracting(mr -> mr.getRefrigerator().getId())
+        CachedMemberRefrigerators updatedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(updatedResult.refrigerators()).hasSize(2)
+            .extracting(CachedRefrigeratorInfo::id)
             .containsExactlyInAnyOrder(refrigerator.getId(), refrigerator2.getId());
     }
 
@@ -118,9 +120,9 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
         assertThat(cache.get(member.getId())).isNotNull();
         assertThat(cache.get(member2.getId())).isNull();
 
-        List<MemberRefrigerator> member2Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member2.getId());
-        assertThat(member2Refrigerators).hasSize(1)
-            .extracting(mr -> mr.getRefrigerator().getId())
+        CachedMemberRefrigerators member2Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+        assertThat(member2Refrigerators.refrigerators()).hasSize(1)
+            .extracting(CachedRefrigeratorInfo::id)
             .containsExactly(refrigerator.getId());
     }
 
@@ -147,11 +149,11 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
         assertThat(cache.get(member.getId())).isNull();
         assertThat(cache.get(member2.getId())).isNull();
 
-        List<MemberRefrigerator> member1Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member.getId());
-        List<MemberRefrigerator> member2Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member2.getId());
+        CachedMemberRefrigerators member1Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        CachedMemberRefrigerators member2Refrigerators = memberRefrigeratorFinder.findAllByMemberId(member2.getId());
 
-        assertThat(member1Refrigerators.get(0).getRefrigerator().getName()).isEqualTo(newName);
-        assertThat(member2Refrigerators.get(0).getRefrigerator().getName()).isEqualTo(newName);
+        assertThat(member1Refrigerators.refrigerators().get(0).name()).isEqualTo(newName);
+        assertThat(member2Refrigerators.refrigerators().get(0).name()).isEqualTo(newName);
     }
 
     @Test
@@ -178,9 +180,9 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
         assertThat(cache.get(member.getId())).isNull();
         assertThat(cache.get(member2.getId())).isNotNull();
 
-        List<MemberRefrigerator> memberRefrigerators = memberRefrigeratorFinder.findAllByMemberId(member.getId());
-        assertThat(memberRefrigerators).hasSize(2)
-            .extracting(mr -> mr.getRefrigerator().getId())
+        CachedMemberRefrigerators memberRefrigerators = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        assertThat(memberRefrigerators.refrigerators()).hasSize(2)
+            .extracting(CachedRefrigeratorInfo::id)
             .containsExactlyInAnyOrder(refrigerator.getId(), refrigerator3.getId());
     }
 
@@ -196,7 +198,7 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
         Cache cache = cacheManager.getCache("myRefrigerators");
         assertThat(cache).isNotNull();
         assertThat(cache.get(member.getId())).isNotNull();
-        assertThat(cache.get(member.getId()).get()).isInstanceOf(List.class);
+        assertThat(cache.get(member.getId()).get()).isInstanceOf(CachedMemberRefrigerators.class);
     }
 
     @Test
@@ -234,16 +236,16 @@ class RefrigeratorCacheIntegrationTest extends IntegrationTestSupport {
         memberRefrigeratorLinker.linkToOwner(member, refrigerator);
 
         // when
-        List<MemberRefrigerator> cachedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
+        CachedMemberRefrigerators cachedResult = memberRefrigeratorFinder.findAllByMemberId(member.getId());
         List<MemberRefrigerator> dbResult = memberRefrigeratorRepository.findAllMyRefrigerators(
             member.getId(),
             soon.fridgely.domain.EntityStatus.ACTIVE
         );
 
         // then
-        assertThat(cachedResult).hasSize(dbResult.size());
-        assertThat(cachedResult)
-            .extracting(mr -> mr.getRefrigerator().getId())
+        assertThat(cachedResult.refrigerators()).hasSize(dbResult.size());
+        assertThat(cachedResult.refrigerators())
+            .extracting(CachedRefrigeratorInfo::id)
             .containsExactlyInAnyOrderElementsOf(
                 dbResult.stream().map(mr -> mr.getRefrigerator().getId()).toList()
             );

--- a/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorServiceUnitTest.java
+++ b/src/test/java/soon/fridgely/domain/refrigerator/service/RefrigeratorServiceUnitTest.java
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import soon.fridgely.domain.member.entity.Member;
+import soon.fridgely.domain.refrigerator.dto.command.CachedMemberRefrigerators;
 import soon.fridgely.domain.refrigerator.dto.command.MemberRefrigeratorKey;
 import soon.fridgely.domain.refrigerator.dto.request.RefrigeratorUpdateRequest;
 import soon.fridgely.domain.refrigerator.dto.response.InvitationCodeResponse;
@@ -133,8 +134,10 @@ class RefrigeratorServiceUnitTest {
             createMemberRefrigerator("Fridge2", RefrigeratorRole.MEMBER)
         );
 
+        CachedMemberRefrigerators cachedRefrigerators = CachedMemberRefrigerators.from(memberId, memberRefrigerators);
+
         given(memberRefrigeratorFinder.findAllByMemberId(memberId))
-            .willReturn(memberRefrigerators);
+            .willReturn(cachedRefrigerators);
 
         // when
         var responses = refrigeratorService.findAllMyRefrigerators(memberId);


### PR DESCRIPTION
- Resolves : #109
---

- 메타데이터 조인 병목 제거: 변경 빈도가 낮은 카테고리 및 회원 정보에 Caffeine 로컬 캐시를 적용하여 DB I/O 부하 감소
- 인프라 한계 검증: vCPU 2, RAM 4 환경에서 1,000 VUs 시 발생하는 리소스 고갈 문제를 확인하고 800 VUs 수준에서의 안정적인 서비스 한계치를 도출

성능 개선 결과

| **지표**            | **최적화 전** | **최종 (Index +Caffeine)** | **개선율**       |
| ----------------- | ------------------- | ------------------------ | ------------- |
| **P95 응답 시간**     | 2.85s               | **350ms**                | **87.7% 감소** |
| **평균 응답 시간**      | 979ms               | **77ms**                 | **92.1% 감소** |
| **에러율 (Error %)** | Crash 발생            | **0.00%**                | **안정성 확보**    |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 서버사이드 카페인 캐시 도입으로 카테고리·나의 냉장고 목록 조회 성능 향상 및 메트릭 수집 추가

* **Bug Fixes / Improvements**
  * 항목 생성·수정·삭제 및 멤버/냉장고 연관 변경 시 관련 캐시 자동 무효화로 데이터 신선도 보장
  * 캐시 만료·용량 정책 적용으로 안정성 향상

* **Tests**
  * 캐시 동작과 무효화 시나리오를 검증하는 통합 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->