### PR TITLE
Fix: MemberDevice 중복 저장 시 Hibernate 세션 오염으로 인한 AssertionFailure 수정

### DIFF
--- a/src/main/java/soon/fridgely/domain/member/service/MemberDeviceAppender.java
+++ b/src/main/java/soon/fridgely/domain/member/service/MemberDeviceAppender.java
@@ -1,0 +1,30 @@
+package soon.fridgely.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import soon.fridgely.domain.member.entity.Member;
+import soon.fridgely.domain.member.entity.MemberDevice;
+import soon.fridgely.domain.member.repository.MemberRepository;
+import soon.fridgely.domain.notification.repository.MemberDeviceRepository;
+import soon.fridgely.global.support.exception.CoreException;
+import soon.fridgely.global.support.exception.ErrorType;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Component
+public class MemberDeviceAppender {
+
+    private final MemberDeviceRepository memberDeviceRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void registerNewDevice(long memberId, String token, LocalDateTime now) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_DATA));
+        memberDeviceRepository.save(MemberDevice.register(member, token, now));
+    }
+
+}

--- a/src/main/java/soon/fridgely/domain/member/service/MemberDeviceManager.java
+++ b/src/main/java/soon/fridgely/domain/member/service/MemberDeviceManager.java
@@ -5,12 +5,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.EntityStatus;
-import soon.fridgely.domain.member.entity.Member;
-import soon.fridgely.domain.member.entity.MemberDevice;
-import soon.fridgely.domain.member.repository.MemberRepository;
 import soon.fridgely.domain.notification.repository.MemberDeviceRepository;
-import soon.fridgely.global.support.exception.CoreException;
-import soon.fridgely.global.support.exception.ErrorType;
 
 import java.time.LocalDateTime;
 
@@ -19,7 +14,7 @@ import java.time.LocalDateTime;
 public class MemberDeviceManager {
 
     private final MemberDeviceRepository memberDeviceRepository;
-    private final MemberRepository memberRepository;
+    private final MemberDeviceAppender memberDeviceAppender;
 
     @Transactional
     public void syncToken(long memberId, String token, LocalDateTime now) {
@@ -32,17 +27,11 @@ public class MemberDeviceManager {
 
     private void registerNewDeviceWithFallback(long memberId, String token, LocalDateTime now) {
         try {
-            registerNewDevice(memberId, token, now);
+            memberDeviceAppender.registerNewDevice(memberId, token, now);
         } catch (DataIntegrityViolationException e) {
             memberDeviceRepository.findByMemberIdAndTokenAndStatus(memberId, token, EntityStatus.ACTIVE)
                 .ifPresent(device -> device.refreshLastUsedAt(now));
         }
-    }
-
-    private void registerNewDevice(long memberId, String token, LocalDateTime now) {
-        Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND_DATA));
-        memberDeviceRepository.saveAndFlush(MemberDevice.register(member, token, now));
     }
 
 }

--- a/src/main/java/soon/fridgely/domain/member/service/MemberDeviceManager.java
+++ b/src/main/java/soon/fridgely/domain/member/service/MemberDeviceManager.java
@@ -3,6 +3,7 @@ package soon.fridgely.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import soon.fridgely.domain.EntityStatus;
 import soon.fridgely.domain.notification.repository.MemberDeviceRepository;
@@ -16,7 +17,7 @@ public class MemberDeviceManager {
     private final MemberDeviceRepository memberDeviceRepository;
     private final MemberDeviceAppender memberDeviceAppender;
 
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void syncToken(long memberId, String token, LocalDateTime now) {
         memberDeviceRepository.findByMemberIdAndTokenAndStatus(memberId, token, EntityStatus.ACTIVE)
             .ifPresentOrElse(

--- a/src/main/java/soon/fridgely/domain/notification/controller/NotificationSettingController.java
+++ b/src/main/java/soon/fridgely/domain/notification/controller/NotificationSettingController.java
@@ -36,4 +36,13 @@ public class NotificationSettingController implements NotificationSettingControl
         return ResponseEntity.ok(ApiResponse.success());
     }
 
+    @Override
+    @PostMapping("/test/expiration")
+    public ResponseEntity<ApiResponse<?>> triggerExpirationTest(
+        @LoginMember Long memberId
+    ) {
+        notificationSettingService.triggerExpirationTest(memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
 }

--- a/src/main/java/soon/fridgely/domain/notification/controller/NotificationSettingControllerDocs.java
+++ b/src/main/java/soon/fridgely/domain/notification/controller/NotificationSettingControllerDocs.java
@@ -49,5 +49,16 @@ public interface NotificationSettingControllerDocs {
         @Parameter(hidden = true) Long memberId
     );
 
+    @Operation(summary = "[테스트] 유통기한 알림 즉시 발송",
+        description = "현재 로그인한 사용자에게 유통기한 임박 알림을 즉시 발송합니다. (테스트 전용)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "알림 발송 요청 성공"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+            content = @Content(schema = @Schema(implementation = soon.fridgely.global.support.response.ApiResponse.class)))
+    })
+    ResponseEntity<soon.fridgely.global.support.response.ApiResponse<?>> triggerExpirationTest(
+        @Parameter(hidden = true) Long memberId
+    );
+
 }
 

--- a/src/main/java/soon/fridgely/domain/notification/service/NotificationSettingService.java
+++ b/src/main/java/soon/fridgely/domain/notification/service/NotificationSettingService.java
@@ -12,6 +12,7 @@ public class NotificationSettingService {
 
     private final NotificationSettingManager notificationSettingManager;
     private final NotificationSettingFinder notificationSettingFinder;
+    private final NotificationProcessor notificationProcessor;
 
     public NotificationSettingDetailResponse findNotificationSetting(long memberId) {
         NotificationSetting setting = notificationSettingFinder.findNotificationSetting(memberId);
@@ -20,6 +21,10 @@ public class NotificationSettingService {
 
     public void updateNotificationSetting(long memberId, NotificationSettingUpdateRequest request) {
         notificationSettingManager.update(memberId, request.toAlertSchedule(), request.enabled());
+    }
+
+    public void triggerExpirationTest(long memberId) {
+        notificationProcessor.processExpiration(memberId);
     }
 
 }

--- a/src/test/java/soon/fridgely/domain/member/service/MemberDeviceManagerUnitTest.java
+++ b/src/test/java/soon/fridgely/domain/member/service/MemberDeviceManagerUnitTest.java
@@ -7,17 +7,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import soon.fridgely.domain.EntityStatus;
-import soon.fridgely.domain.member.entity.Member;
 import soon.fridgely.domain.member.entity.MemberDevice;
-import soon.fridgely.domain.member.repository.MemberRepository;
 import soon.fridgely.domain.notification.repository.MemberDeviceRepository;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,7 +26,7 @@ class MemberDeviceManagerUnitTest {
     private MemberDeviceRepository memberDeviceRepository;
 
     @Mock
-    private MemberRepository memberRepository;
+    private MemberDeviceAppender memberDeviceAppender;
 
     @Test
     void 동시_요청으로_DataIntegrityViolationException_발생_시_기존_디바이스의_마지막_사용_시간을_갱신한다() {
@@ -40,16 +36,14 @@ class MemberDeviceManagerUnitTest {
         LocalDateTime now = LocalDateTime.now();
 
         MemberDevice existingDevice = mock(MemberDevice.class);
-        Member mockMember = mock(Member.class);
 
         // 첫 조회: 없음 → 신규 등록 시도 / 두 번째 조회(fallback): 다른 스레드가 먼저 등록한 디바이스 반환
         given(memberDeviceRepository.findByMemberIdAndTokenAndStatus(memberId, token, EntityStatus.ACTIVE))
             .willReturn(Optional.empty())
             .willReturn(Optional.of(existingDevice));
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.of(mockMember));
-        given(memberDeviceRepository.saveAndFlush(any()))
-            .willThrow(new DataIntegrityViolationException("unique constraint violation"));
+        willThrow(new DataIntegrityViolationException("unique constraint violation"))
+            .given(memberDeviceAppender).registerNewDevice(memberId, token, now);
 
         // when
         memberDeviceManager.syncToken(memberId, token, now);


### PR DESCRIPTION
- Resolves : #189 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 만료(유통기한) 알림 즉시 전송 테스트용 엔드포인트 및 해당 서비스 기능 추가
* **Refactor**
  * 디바이스 등록 로직을 전담하는 신규 서비스로 분리
  * 동시성 상황에서의 디바이스 등록 플로우 개선 및 트랜잭션 처리 방식 조정
* **Documentation**
  * 테스트용 만료 알림 엔드포인트에 대한 API 문서 추가
* **Tests**
  * 동시성 시나리오 관련 단위 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->