### PR TITLE
만료 당일 식품 FoodStatus가 BLACK이 아닌 RED로 저장되는 버그 수정

### DIFF
--- a/src/main/java/soon/fridgely/domain/food/service/FoodStatusProcessor.java
+++ b/src/main/java/soon/fridgely/domain/food/service/FoodStatusProcessor.java
@@ -22,7 +22,7 @@ public class FoodStatusProcessor {
      */
     @Transactional
     public int bulkUpdate(LocalDate today) {
-        LocalDateTime redStart = today.atStartOfDay();
+        LocalDateTime redStart = today.plusDays(1).atStartOfDay();
         LocalDateTime yellowStart = today.plusDays(FoodStatus.RED.nextThresholdDay()).atStartOfDay();
         LocalDateTime greenStart = today.plusDays(FoodStatus.YELLOW.nextThresholdDay()).atStartOfDay();
 

--- a/src/test/java/soon/fridgely/domain/food/service/FoodStatusSchedulerIntegrationTest.java
+++ b/src/test/java/soon/fridgely/domain/food/service/FoodStatusSchedulerIntegrationTest.java
@@ -87,6 +87,28 @@ class FoodStatusSchedulerIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
+    void BLACK_RED_경계값인_당일_만료는_BLACK이고_D플러스1은_RED이다() {
+        // given
+        LocalDate today = LocalDate.now();
+        Food todayExpiry = foodRepository.save(
+            food(refrigerator, member, category, today.atStartOfDay(), FoodStatus.GREEN).sample()
+        );
+        Food tomorrowExpiry = foodRepository.save(
+            food(refrigerator, member, category, today.plusDays(1).atStartOfDay(), FoodStatus.GREEN).sample()
+        );
+
+        // when
+        foodStatusScheduler.updateFoodStatuses();
+
+        // then
+        Food updatedToday = foodRepository.findById(todayExpiry.getId()).orElseThrow();
+        assertThat(updatedToday.getFoodStatus()).isEqualTo(FoodStatus.BLACK);
+
+        Food updatedTomorrow = foodRepository.findById(tomorrowExpiry.getId()).orElseThrow();
+        assertThat(updatedTomorrow.getFoodStatus()).isEqualTo(FoodStatus.RED);
+    }
+
+    @Test
     void RED_YELLOW_경계값인_D플러스10은_RED이고_D플러스11은_YELLOW이다() {
         // given
         LocalDate today = LocalDate.now();


### PR DESCRIPTION
- Resolves : #243 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 식품 만료 상태 경계값 계산 로직을 조정했습니다.

* **Tests**
  * 만료일 경계값에 따른 식품 상태 갱신을 검증하는 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->