### PR TITLE
Feat: 로그인·토큰 재발급 엔드포인트 Rate Limit 추가

### DIFF
--- a/src/main/java/soon/fridgely/domain/auth/controller/AuthController.java
+++ b/src/main/java/soon/fridgely/domain/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import soon.fridgely.domain.auth.dto.request.LoginRequest;
 import soon.fridgely.domain.auth.dto.request.ReissueTokenRequest;
 import soon.fridgely.domain.auth.service.AuthService;
 import soon.fridgely.global.security.annotation.LoginMember;
+import soon.fridgely.global.security.ratelimit.LoginRateLimit;
 import soon.fridgely.global.security.dto.response.TokenResponse;
 import soon.fridgely.global.support.response.ApiResponse;
 
@@ -22,6 +23,7 @@ public class AuthController implements AuthControllerDocs {
     private final AuthService authService;
 
     @Override
+    @LoginRateLimit
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<TokenResponse>> login(
         @RequestBody @Valid LoginRequest request
@@ -31,6 +33,7 @@ public class AuthController implements AuthControllerDocs {
     }
 
     @Override
+    @LoginRateLimit
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<TokenResponse>> reissue(
         @RequestBody @Valid ReissueTokenRequest request

--- a/src/main/java/soon/fridgely/global/security/ratelimit/LoginRateLimit.java
+++ b/src/main/java/soon/fridgely/global/security/ratelimit/LoginRateLimit.java
@@ -1,0 +1,11 @@
+package soon.fridgely.global.security.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginRateLimit {
+}

--- a/src/main/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspect.java
+++ b/src/main/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspect.java
@@ -1,0 +1,63 @@
+package soon.fridgely.global.security.ratelimit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import soon.fridgely.global.support.exception.CoreException;
+import soon.fridgely.global.support.exception.ErrorType;
+import soon.fridgely.global.support.logging.SlackMarkers;
+
+import java.time.Duration;
+
+@Slf4j
+@RequiredArgsConstructor
+@Aspect
+@Component
+@ConditionalOnProperty(name = "spring.cache.type", havingValue = "redis")
+public class LoginRateLimitAspect {
+
+    private static final int MAX_REQUESTS = 10;
+    private static final long PERIOD_SECONDS = 60L;
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Before("@annotation(soon.fridgely.global.security.ratelimit.LoginRateLimit)")
+    public void checkRateLimit() {
+        String ip = extractClientIp();
+        String key = "login:ratelimit:" + ip;
+
+        Long count = stringRedisTemplate.opsForValue().increment(key);
+        Long ttl = stringRedisTemplate.getExpire(key);
+        if (ttl != null && ttl == -1L) {
+            stringRedisTemplate.expire(key, Duration.ofSeconds(PERIOD_SECONDS));
+        }
+        if (count != null && count > MAX_REQUESTS) {
+            log.warn(SlackMarkers.SYSTEM, "[LoginRateLimitAspect] 로그인 Rate Limit 초과. (IP={})", ip);
+            throw new CoreException(ErrorType.LOGIN_RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    private String extractClientIp() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (StringUtils.hasText(forwarded)) {
+            return forwarded.split(",")[0].trim();
+        }
+
+        String realIp = request.getHeader("X-Real-IP");
+        if (StringUtils.hasText(realIp)) {
+            return realIp;
+        }
+
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspect.java
+++ b/src/main/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspect.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import soon.fridgely.global.support.exception.ErrorType;
 import soon.fridgely.global.support.logging.SlackMarkers;
 
 import java.time.Duration;
+import java.util.Arrays;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,6 +30,9 @@ public class LoginRateLimitAspect {
     private static final long PERIOD_SECONDS = 60L;
 
     private final StringRedisTemplate stringRedisTemplate;
+
+    @Value("${auth.rate-limit.trusted-proxies:}")
+    private String trustedProxiesConfig;
 
     @Before("@annotation(soon.fridgely.global.security.ratelimit.LoginRateLimit)")
     public void checkRateLimit() {
@@ -47,6 +52,11 @@ public class LoginRateLimitAspect {
 
     private String extractClientIp() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String remoteAddr = request.getRemoteAddr();
+
+        if (!isTrustedProxy(remoteAddr)) {
+            return remoteAddr;
+        }
 
         String forwarded = request.getHeader("X-Forwarded-For");
         if (StringUtils.hasText(forwarded)) {
@@ -58,6 +68,15 @@ public class LoginRateLimitAspect {
             return realIp;
         }
 
-        return request.getRemoteAddr();
+        return remoteAddr;
+    }
+
+    private boolean isTrustedProxy(String remoteAddr) {
+        if (!StringUtils.hasText(trustedProxiesConfig)) {
+            return false;
+        }
+        return Arrays.stream(trustedProxiesConfig.split(","))
+            .map(String::trim)
+            .anyMatch(remoteAddr::equals);
     }
 }

--- a/src/main/java/soon/fridgely/global/support/exception/ErrorType.java
+++ b/src/main/java/soon/fridgely/global/support/exception/ErrorType.java
@@ -30,6 +30,7 @@ public enum ErrorType {
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 파일 형식입니다.", LogLevel.WARN),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 이미지 URL입니다.", LogLevel.WARN),
     UPLOAD_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "업로드 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", LogLevel.WARN),
+    LOGIN_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "로그인 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", LogLevel.WARN),
 
     // 멤버 오류
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "이미 사용 중인 ID입니다.", LogLevel.WARN),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,10 @@ upload:
     max-requests: 10
     period-seconds: 60
 
+auth:
+  rate-limit:
+    trusted-proxies: # nginx 등 신뢰할 프록시 IP 목록 (쉼표 구분). 미설정 시 remoteAddr 직접 사용
+
 # 공통 Resilience4j 설정
 resilience4j:
   retry:

--- a/src/test/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspectUnitTest.java
+++ b/src/test/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspectUnitTest.java
@@ -10,10 +10,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import soon.fridgely.global.support.exception.CoreException;
 import soon.fridgely.global.support.exception.ErrorType;
+
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,7 +62,7 @@ class LoginRateLimitAspectUnitTest {
     }
 
     @Test
-    void TTL이_없는_키는_expire를_설정한다() {
+    void TTL이_없는_키는_60초로_expire를_설정한다() {
         // given
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.increment("login:ratelimit:192.168.1.1")).willReturn(1L);
@@ -69,7 +72,7 @@ class LoginRateLimitAspectUnitTest {
         aspect.checkRateLimit();
 
         // then
-        then(stringRedisTemplate).should().expire(eq("login:ratelimit:192.168.1.1"), any());
+        then(stringRedisTemplate).should().expire(eq("login:ratelimit:192.168.1.1"), eq(Duration.ofSeconds(60)));
     }
 
     @Test
@@ -100,43 +103,77 @@ class LoginRateLimitAspectUnitTest {
     }
 
     @Test
-    void XForwardedFor_헤더의_첫번째_IP를_Rate_Limit_키로_사용한다() {
-        // given
+    void 신뢰_프록시에서_온_요청은_XForwardedFor_첫번째_IP를_Rate_Limit_키로_사용한다() {
+        // given: MockHttpServletRequest 기본 remoteAddr = "127.0.0.1"
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("X-Forwarded-For", "10.0.0.1, 10.0.0.2");
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        ReflectionTestUtils.setField(aspect, "trustedProxiesConfig", "127.0.0.1");
 
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.increment("login:ratelimit:10.0.0.1")).willReturn(5L);
         given(stringRedisTemplate.getExpire("login:ratelimit:10.0.0.1")).willReturn(30L);
 
-        // when & then
-        assertThatCode(() -> aspect.checkRateLimit()).doesNotThrowAnyException();
+        // when
+        aspect.checkRateLimit();
+
+        // then
+        then(valueOperations).should().increment("login:ratelimit:10.0.0.1");
+        then(stringRedisTemplate).should().getExpire("login:ratelimit:10.0.0.1");
     }
 
     @Test
-    void XRealIP_헤더가_있으면_해당_IP를_Rate_Limit_키로_사용한다() {
-        // given
+    void 신뢰_프록시에서_온_요청은_XRealIP를_Rate_Limit_키로_사용한다() {
+        // given: MockHttpServletRequest 기본 remoteAddr = "127.0.0.1"
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("X-Real-IP", "10.0.0.3");
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+        ReflectionTestUtils.setField(aspect, "trustedProxiesConfig", "127.0.0.1");
 
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.increment("login:ratelimit:10.0.0.3")).willReturn(5L);
         given(stringRedisTemplate.getExpire("login:ratelimit:10.0.0.3")).willReturn(30L);
 
-        // when & then
-        assertThatCode(() -> aspect.checkRateLimit()).doesNotThrowAnyException();
+        // when
+        aspect.checkRateLimit();
+
+        // then
+        then(valueOperations).should().increment("login:ratelimit:10.0.0.3");
+        then(stringRedisTemplate).should().getExpire("login:ratelimit:10.0.0.3");
+    }
+
+    @Test
+    void 비신뢰_프록시에서_전달된_XForwardedFor_헤더는_무시하고_remoteAddr를_사용한다() {
+        // given: trustedProxiesConfig 미설정 (기본값 빈 문자열) → 헤더 무시
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("1.2.3.4");
+        request.addHeader("X-Forwarded-For", "5.6.7.8");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:1.2.3.4")).willReturn(5L);
+        given(stringRedisTemplate.getExpire("login:ratelimit:1.2.3.4")).willReturn(30L);
+
+        // when
+        aspect.checkRateLimit();
+
+        // then: X-Forwarded-For의 5.6.7.8이 아닌 remoteAddr 1.2.3.4로 카운팅
+        then(valueOperations).should().increment("login:ratelimit:1.2.3.4");
+        then(stringRedisTemplate).should().getExpire("login:ratelimit:1.2.3.4");
     }
 
     @Test
     void 헤더가_없으면_remoteAddr를_Rate_Limit_키로_사용한다() {
-        // given: setUp()에서 remoteAddr = "192.168.1.1" 설정됨
+        // given: setUp()에서 remoteAddr = "192.168.1.1", trustedProxiesConfig 미설정
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.increment("login:ratelimit:192.168.1.1")).willReturn(5L);
         given(stringRedisTemplate.getExpire("login:ratelimit:192.168.1.1")).willReturn(30L);
 
-        // when & then
-        assertThatCode(() -> aspect.checkRateLimit()).doesNotThrowAnyException();
+        // when
+        aspect.checkRateLimit();
+
+        // then
+        then(valueOperations).should().increment("login:ratelimit:192.168.1.1");
+        then(stringRedisTemplate).should().getExpire("login:ratelimit:192.168.1.1");
     }
 }

--- a/src/test/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspectUnitTest.java
+++ b/src/test/java/soon/fridgely/global/security/ratelimit/LoginRateLimitAspectUnitTest.java
@@ -1,0 +1,142 @@
+package soon.fridgely.global.security.ratelimit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import soon.fridgely.global.support.exception.CoreException;
+import soon.fridgely.global.support.exception.ErrorType;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class LoginRateLimitAspectUnitTest {
+
+    @InjectMocks
+    private LoginRateLimitAspect aspect;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr("192.168.1.1");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void 요청_횟수가_한도_이하이면_예외가_발생하지_않는다() {
+        // given
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:192.168.1.1")).willReturn(5L);
+        given(stringRedisTemplate.getExpire("login:ratelimit:192.168.1.1")).willReturn(30L);
+
+        // when & then
+        assertThatCode(() -> aspect.checkRateLimit()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void TTL이_없는_키는_expire를_설정한다() {
+        // given
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:192.168.1.1")).willReturn(1L);
+        given(stringRedisTemplate.getExpire("login:ratelimit:192.168.1.1")).willReturn(-1L);
+
+        // when
+        aspect.checkRateLimit();
+
+        // then
+        then(stringRedisTemplate).should().expire(eq("login:ratelimit:192.168.1.1"), any());
+    }
+
+    @Test
+    void TTL이_설정된_키는_expire를_재설정하지_않는다() {
+        // given
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:192.168.1.1")).willReturn(5L);
+        given(stringRedisTemplate.getExpire("login:ratelimit:192.168.1.1")).willReturn(30L);
+
+        // when
+        aspect.checkRateLimit();
+
+        // then
+        then(stringRedisTemplate).should(never()).expire(any(), any());
+    }
+
+    @Test
+    void 요청_횟수가_한도를_초과하면_예외가_발생한다() {
+        // given
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:192.168.1.1")).willReturn(11L);
+
+        // expected
+        assertThatThrownBy(() -> aspect.checkRateLimit())
+            .isInstanceOf(CoreException.class)
+            .extracting("errorType")
+            .isEqualTo(ErrorType.LOGIN_RATE_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    void XForwardedFor_헤더의_첫번째_IP를_Rate_Limit_키로_사용한다() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Forwarded-For", "10.0.0.1, 10.0.0.2");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:10.0.0.1")).willReturn(5L);
+        given(stringRedisTemplate.getExpire("login:ratelimit:10.0.0.1")).willReturn(30L);
+
+        // when & then
+        assertThatCode(() -> aspect.checkRateLimit()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void XRealIP_헤더가_있으면_해당_IP를_Rate_Limit_키로_사용한다() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-Real-IP", "10.0.0.3");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:10.0.0.3")).willReturn(5L);
+        given(stringRedisTemplate.getExpire("login:ratelimit:10.0.0.3")).willReturn(30L);
+
+        // when & then
+        assertThatCode(() -> aspect.checkRateLimit()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void 헤더가_없으면_remoteAddr를_Rate_Limit_키로_사용한다() {
+        // given: setUp()에서 remoteAddr = "192.168.1.1" 설정됨
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("login:ratelimit:192.168.1.1")).willReturn(5L);
+        given(stringRedisTemplate.getExpire("login:ratelimit:192.168.1.1")).willReturn(30L);
+
+        // when & then
+        assertThatCode(() -> aspect.checkRateLimit()).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
- Resolves : #246 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인 및 토큰 재발급 요청에 대한 레이트 리미팅 기능을 추가했습니다.
  * 클라이언트 IP별로 60초당 최대 10회 요청으로 제한하며, 초과 시 요청이 거부됩니다.

* **Tests**
  * 레이트 리미팅 동작을 검증하는 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->